### PR TITLE
Fix SDL_SetVideoModeScaling function

### DIFF
--- a/src/video/psp2/SDL_psp2video.c
+++ b/src/video/psp2/SDL_psp2video.c
@@ -427,7 +427,7 @@ static int PSP2_FlipHWSurface(_THIS, SDL_Surface *surface)
 // custom psp2 function for centering/scaling main screen surface (texture)
 void SDL_SetVideoModeScaling(int x, int y, float w, float h)
 {
-	SDL_Surface *surface = SDL_GetVideoSurface();
+	SDL_Surface *surface = SDL_VideoSurface;
 
 	if (surface != NULL && surface->hwdata != NULL)
 	{


### PR DESCRIPTION
It turns out that SDL_GetVideoSurface() does not always return the actual screen surface. SDL_VideoSurface, on the other hand, always points to the actual display surface.

This fixes problems with SDL_SetVideoModeScaling() not working in some apps (Zeldo OB), but working in other apps (VitaWolfen).
